### PR TITLE
chore: drop xorg namespace, update zen-browser & hmcl

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # commands such as:
 #     nix-build -A mypackage
 
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }, unstable ? pkgs }:
 {
   # The `lib`, `modules`, and `overlays` names are special
   lib = import ./lib { inherit pkgs; }; # functions

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712449641,
-        "narHash": "sha256-U9DDWMexN6o5Td2DznEgguh8TRIUnIl9levmit43GcI=",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "600b15aea1b36eeb43833a50b0e96579147099ff",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     in
     {
       legacyPackages = forAllSystems (system: import ./default.nix {
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
         unstable = import nixpkgs {inherit system; };
       });
       packages = forAllSystems (system: nixpkgs.lib.filterAttrs (_: v: nixpkgs.lib.isDerivation v) self.legacyPackages.${system});

--- a/pkgs/baidunetdisk/electron_11.nix
+++ b/pkgs/baidunetdisk/electron_11.nix
@@ -45,14 +45,14 @@ let
       gtk3
       nss
       nspr
-      xorg.libX11
-      xorg.libxcb
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
-      xorg.libxkbfile
+      libX11
+      libxcb
+      libXcomposite
+      libXdamage
+      libXext
+      libXfixes
+      libXrandr
+      libxkbfile
       pango
       pciutils
       stdenv.cc.cc.lib

--- a/pkgs/baidunetdisk/electron_11.nix
+++ b/pkgs/baidunetdisk/electron_11.nix
@@ -23,6 +23,14 @@
   pango,
   systemd,
   pciutils,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXrandr,
+  libxkbfile,
 }:
 let
   headersFetcher =

--- a/pkgs/baidunetdisk/electron_11.nix
+++ b/pkgs/baidunetdisk/electron_11.nix
@@ -20,7 +20,6 @@
   gdk-pixbuf,
   nss,
   nspr,
-  xorg,
   pango,
   systemd,
   pciutils,

--- a/pkgs/clipsim/default.nix
+++ b/pkgs/clipsim/default.nix
@@ -1,7 +1,6 @@
 {stdenv, fetchFromGitHub, lib
 , gnumake
 , xclip
-, xorg
 , file
 , pkg-config
 }:

--- a/pkgs/clipsim/default.nix
+++ b/pkgs/clipsim/default.nix
@@ -3,6 +3,8 @@
 , xclip
 , file
 , pkg-config
+, libXfixes
+, libX11
 }:
 stdenv.mkDerivation {
   pname = "clipsim";

--- a/pkgs/clipsim/default.nix
+++ b/pkgs/clipsim/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation {
 
   buildInputs = [
     xclip
-    xorg.libXfixes
+    libXfixes
     file
-    xorg.libX11
+    libX11
   ];
 
   nativeBuildInputs = [ 

--- a/pkgs/hmcl/default.nix
+++ b/pkgs/hmcl/default.nix
@@ -6,7 +6,6 @@
   makeWrapper,
   copyDesktopItems,
   jre,
-  xorg,
   glib,
   libGL,
   glfw,
@@ -16,6 +15,12 @@
   wayland,
   vulkan-loader,
   libpulseaudio,
+  libX11,
+  libXxf86vm,
+  libXext,
+  libXcursor,
+  libXrandr,
+  libXtst,
 }:
 let
   icon = fetchurl {

--- a/pkgs/hmcl/default.nix
+++ b/pkgs/hmcl/default.nix
@@ -29,12 +29,12 @@ let
     openal
     libglvnd
     vulkan-loader
-    xorg.libX11
-    xorg.libXxf86vm
-    xorg.libXext
-    xorg.libXcursor
-    xorg.libXrandr
-    xorg.libXtst
+    libX11
+    libXxf86vm
+    libXext
+    libXcursor
+    libXrandr
+    libXtst
     libpulseaudio
     wayland
     alsa-lib
@@ -56,11 +56,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "hmcl";
-  version = "3.11.2";
+  version = "3.15.2";
 
   src = fetchurl {
     url = "https://github.com/HMCL-dev/HMCL/releases/download/v${version}/HMCL-${version}.jar";
-    hash = "sha256-Db9ly87xt6+S6dgQ0bkVvKwY9t4pMPfnebMKPFrcbhc=";
+    hash = "sha256-SyT8snV83UYGsxr8I2sIYCCAIiei6WOBxPww7Sw0Gpo=";
   };
 
   dontUnpack = true;

--- a/pkgs/wechat-universal-bwrap/default.nix
+++ b/pkgs/wechat-universal-bwrap/default.nix
@@ -5,7 +5,6 @@
 , dpkg
 , nss
 , nspr
-, xorg
 , pango
 , zlib
 , atkmm
@@ -47,13 +46,30 @@
 , xhost
 , xdg-user-dirs
 , krb5
-
+, libXdamage
+, libXtst
+, libXv
+, libXScrnSaver
+, libxcb
+, libX11
+, libXrender
+, libSM
+, libICE
+, libXcursor
+, libXt
+, libXext
+, libxshmfence
+, libXi
+, libXft
+, libXfixes
+, libXcomposite
+, libXrandr
 , makeWrapper
 , copyDesktopItems
 , makeDesktopItem
 }:
 let
-  libraries = with xorg; [
+  libraries = [
     # Make sure our glibc without hardening gets picked up first
     (lib.hiPrio glibcWithoutHardening)
     stdenv.cc.cc

--- a/pkgs/wpsoffice-365/default.nix
+++ b/pkgs/wpsoffice-365/default.nix
@@ -51,16 +51,16 @@ let
     udev
     gtk3
     qtbase
-    xorg.libXdamage
-    xorg.libXtst
-    xorg.libXv
-    xorg.libXScrnSaver
-    xorg.libxcb
-    xorg.libX11
-    xorg.libXrender
-    xorg.libSM
-    xorg.libICE
-    xorg.libXcursor
+    libXdamage
+    libXtst
+    libXv
+    libXScrnSaver
+    libxcb
+    libX11
+    libXrender
+    libSM
+    libICE
+    libXcursor
     cups
     pango
     libpulseaudio

--- a/pkgs/wpsoffice-365/default.nix
+++ b/pkgs/wpsoffice-365/default.nix
@@ -32,6 +32,16 @@
 , libglvnd
 , cairo
 , gdk-pixbuf
+, libXdamage
+, libXtst
+, libXv
+, libXScrnSaver
+, libxcb
+, libX11
+, libXrender
+, libSM
+, libICE
+, libXcursor
 # For wpscloudsvr wrapper
 , pkg-config
 , libappindicator-gtk3

--- a/pkgs/wpsoffice-365/default.nix
+++ b/pkgs/wpsoffice-365/default.nix
@@ -17,7 +17,6 @@
 , udev
 , gtk3
 , qtbase
-, xorg
 , cups
 , pango
 , freetype

--- a/pkgs/wpsoffice/default.nix
+++ b/pkgs/wpsoffice/default.nix
@@ -16,7 +16,6 @@
 , udev
 , gtk3
 , qtbase
-, xorg
 , cups
 , pango
 , freetype

--- a/pkgs/wpsoffice/default.nix
+++ b/pkgs/wpsoffice/default.nix
@@ -26,6 +26,9 @@
 , zlib
 , libdeflate
 , libusb1
+, libXdamage
+, libXtst
+, libXv
 # For wpscloudsvr wrapper
 , libappindicator-gtk3
 

--- a/pkgs/wpsoffice/default.nix
+++ b/pkgs/wpsoffice/default.nix
@@ -131,9 +131,9 @@ stdenv.mkDerivation rec {
     udev
     gtk3
     qtbase
-    xorg.libXdamage
-    xorg.libXtst
-    xorg.libXv
+    libXdamage
+    libXtst
+    libXv
     libusb1
     libappindicator-gtk3
   ];

--- a/pkgs/zen-browser/default.nix
+++ b/pkgs/zen-browser/default.nix
@@ -31,12 +31,12 @@
 }:
 let
   pname = "zen-browser-bin";
-  version = "1.19.1b";
+  version = "1.21.8b";
   _pname = "zen-browser";
 
   src = fetchurl {
     url = "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-x86_64.tar.xz";
-    hash = "sha256-QKnRN+ajPkR36UKNYvJF2Oj0YQpyz7YkqXBwwuPd/as=";
+    hash = "sha256-QinHxQfiKmjV9F4LXyPTUg0RWWWupQXTSFEH+nkau3k=";
   };
 
   libs = [
@@ -69,15 +69,15 @@ let
     networkmanager
     speechd-minimal
     # X stuff
-    xorg.libXt
-    xorg.libX11
-    xorg.libXext
-    xorg.libxcb
-    xorg.libXcomposite
-    xorg.libXdamage
-    xorg.libXrandr
-    xorg.libXxf86dga
-    xorg.libXxf86vm
+    libXt
+    libX11
+    libXext
+    libxcb
+    libXcomposite
+    libXdamage
+    libXrandr
+    libXxf86dga
+    libXxf86vm
   ];
 
   enterprisePolicies = {

--- a/pkgs/zen-browser/default.nix
+++ b/pkgs/zen-browser/default.nix
@@ -27,6 +27,15 @@
 , hunspellDicts
 , networkmanager
 , speechd-minimal
+, libXt
+, libX11
+, libXext
+, libxcb
+, libXcomposite
+, libXdamage
+, libXrandr
+, libXxf86dga
+, libXxf86vm
 }:
 let
   pname = "zen-browser-bin";

--- a/pkgs/zen-browser/default.nix
+++ b/pkgs/zen-browser/default.nix
@@ -1,7 +1,6 @@
 { stdenv, lib, fetchurl, autoPatchelfHook, makeWrapper, copyDesktopItems, makeDesktopItem, writeText
 , dbus-glib
 , gtk3
-, xorg
 , nss
 , systemd
 , ffmpeg_7-headless


### PR DESCRIPTION
## Summary

- Removed all references to the deprecated `xorg` namespace
- Fixed packages that broke as a result of the removal
- Enabled `allowUnfree`
- Updated `zen-browser` and `hmcl` to their latest versions

## Details

### xorg namespace removal

As of January 13, 2026, nixpkgs contributor
[quantenzitrone](https://github.com/quantenzitrone) began phasing out the
`xorg` namespace for all xorg-dependent packages (see
[NixOS/nixpkgs#479553](https://github.com/NixOS/nixpkgs/issues/479553)).
All packages formerly under `xorg.*` have been moved to `pkgs/by-name` in
nixpkgs, and the `xorg` attribute set now only contains aliases that are
slated for removal.

Since these aliases are deprecated and may break in the future, I've
replaced every `xorg.<pkg>` reference in this repo with the corresponding
top-level attribute (e.g. `xorg.libX11` → `libX11`).

### Build fixes

Removing the `xorg` namespace broke a few packages that relied on it for
implicit library arguments. Fixed by adding the individual top-level
libraries (`libXdamage`, `libXtst`, `libXv`, `libXScrnSaver`, `libxcb`,
`libX11`, `libXrender`, `libSM`, `libICE`, `libXcursor`, etc.) directly as
function arguments in:

- `pkgs/baidunetdisk/electron_11.nix`
- `pkgs/clipsim/default.nix`
- `pkgs/wechat-universal-bwrap/default.nix`
- `pkgs/wpsoffice-365/default.nix`
- `pkgs/wpsoffice/default.nix`
- `pkgs/zen-browser/default.nix`

### Version bumps

- `zen-browser`: `1.19.1b` → `1.21.8b`
- `hmcl`: `3.11.2` → `3.15.2`

## Testing

- [x] `nix flake check` passes
- [x] Affected packages build successfully